### PR TITLE
Property-based tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,8 @@ fix = "PATCH"
 
 [dependency-groups]
 dev = [
+    "hypothesis>=6.155.2",
+    "inline-snapshot>=0.34.1",
     "pytest>=9.0.2",
     "pytest-cov>=7.1.0",
     "pytest-markdown-docs>=0.6",

--- a/tests/hypothesis/conftest.py
+++ b/tests/hypothesis/conftest.py
@@ -1,0 +1,5 @@
+from hypothesis import settings
+
+settings.register_profile("deep", max_examples=10000)
+settings.load_profile("default")  # default max_examples=100
+# settings.load_profile("deep")

--- a/tests/hypothesis/conftest.py
+++ b/tests/hypothesis/conftest.py
@@ -1,5 +1,7 @@
 from hypothesis import settings
 
+settings.register_profile("no_deadline", deadline=None)
 settings.register_profile("deep", max_examples=10000)
 settings.load_profile("default")  # default max_examples=100
+# settings.load_profile("no_deadline")
 # settings.load_profile("deep")

--- a/tests/hypothesis/test_ortho.py
+++ b/tests/hypothesis/test_ortho.py
@@ -5,6 +5,7 @@ from inline_snapshot import snapshot
 import numpy as np
 
 from wdm_transform.backends import NUMPY_BACKEND
+from wdm_transform.backends.jax_backend import load_jax_backend
 from wdm_transform.windows import gnmf
 
 
@@ -37,9 +38,10 @@ def two_ns_one_m(draw, min=2):
     return (Nt, Nf, n1, n2, m)
 
 
-# Numerical values tuned so that no counterexamples would be found
-# in the tests.
-positive = st.floats(
+# Desired level of precision on inner products.
+atol = 1e-8
+
+pos_real = st.floats(
     min_value=1e-200,
     max_value=1e200,
     exclude_min=True,
@@ -51,9 +53,13 @@ positive = st.floats(
 # Using max_value=0.5, exclude_max=True isn't enough.
 shape_param_a = st.floats(0, 0.5 - 1e-7)
 
-# Desired level of precision on inner products.
-atol = 1e-8
+# d != 1 not implemented
+shape_param_d = st.just(1)
+# shape_param_d = st.floats(min_value=1)
 
+# JAX disabled because very slow, maybe JIT-in-a-loop overhead?
+JAX_BACKEND = load_jax_backend()
+backend_gen = st.just(NUMPY_BACKEND) #| st.just(JAX_BACKEND)
 
 def ortho_condition(Nf, Nt, n1, n2, m1, m2):
     if m1 == m2:
@@ -65,48 +71,50 @@ def ortho_condition(Nf, Nt, n1, n2, m1, m2):
     return 0
 
 
-@given(one_n_two_ms(min=100), positive, shape_param_a)
-def test_ortho_twom(args, dT, a):
+@given(one_n_two_ms(min=100), pos_real, shape_param_a, shape_param_d, backend_gen)
+def test_ortho_twom(args, dT, a, d, backend):
     Nt, Nf, n, m1, m2 = args
     note(f"{Nt=}, {Nf=}")
     note(f"{n=}, {m1=}, {m2=}")
+    xp = backend.xp
 
-    freqs = np.fft.fftfreq(Nt * Nf, dT / Nf)
-    w1 = gnmf(NUMPY_BACKEND, n, m1, freqs, dT, Nf, a, d=1)
-    w2 = gnmf(NUMPY_BACKEND, n, m2, freqs, dT, Nf, a, d=1)
+    freqs = xp.fft.fftfreq(Nt * Nf, dT / Nf)
+    w1 = gnmf(backend, n, m1, freqs, dT, Nf, a, d)
+    w2 = gnmf(backend, n, m2, freqs, dT, Nf, a, d)
 
-    norm_squared = np.sum(w1.conj() * w1).real
+    norm_squared = xp.sum(w1.conj() * w1).real
 
     note(f"{norm_squared = }")
     note(f"{w1.shape=}")
     note(f"{w2.shape=}")
 
-    inner = np.sum(w1.conj() * w2)
+    inner = xp.sum(w1.conj() * w2)
     note(f"{inner = }")
     note(f"{abs(inner) = }")
-    assert np.isclose(inner, ortho_condition(Nf, Nt, n, n, m1, m2), atol=atol)
+    assert xp.isclose(inner, ortho_condition(Nf, Nt, n, n, m1, m2), atol=atol)
 
 
-@given(two_ns_one_m(min=10), positive, shape_param_a)
-def test_ortho_twon(args, dT, a):
+@given(two_ns_one_m(min=10), pos_real, shape_param_a, shape_param_d, backend_gen)
+def test_ortho_twon(args, dT, a, d, backend):
     Nt, Nf, n1, n2, m = args
     note(f"{Nt=}, {Nf=}")
     note(f"{n1=}, {n2=}, {m=}")
+    xp = backend.xp
 
-    freqs = np.fft.fftfreq(Nt * Nf, dT / Nf)
-    w1 = gnmf(NUMPY_BACKEND, n1, m, freqs, dT, Nf, a, d=1)
-    w2 = gnmf(NUMPY_BACKEND, n2, m, freqs, dT, Nf, a, d=1)
+    freqs = xp.fft.fftfreq(Nt * Nf, dT / Nf)
+    w1 = gnmf(backend, n1, m, freqs, dT, Nf, a, d)
+    w2 = gnmf(backend, n2, m, freqs, dT, Nf, a, d)
 
-    norm_squared = np.sum(w1.conj() * w1).real
+    norm_squared = xp.sum(w1.conj() * w1).real
 
     note(f"{norm_squared = }")
     note(f"{w1.shape=}")
     note(f"{w2.shape=}")
 
-    inner = np.sum(w1.conj() * w2)
+    inner = xp.sum(w1.conj() * w2)
     note(f"{inner = }")
     note(f"{abs(inner) = }")
-    assert np.isclose(inner, ortho_condition(Nf, Nt, n1, n2, m, m), atol=atol)
+    assert xp.isclose(inner, ortho_condition(Nf, Nt, n1, n2, m, m), atol=atol)
 
 
 def test_normalization():

--- a/tests/hypothesis/test_ortho.py
+++ b/tests/hypothesis/test_ortho.py
@@ -1,0 +1,179 @@
+import pytest
+from hypothesis import given, example, note, strategies as st
+from inline_snapshot import snapshot
+
+import numpy as np
+
+from wdm_transform.backends import NUMPY_BACKEND
+from wdm_transform.windows import gnmf
+
+
+@st.composite
+def grid(draw, min=2):
+    # all that we claim in the paper: our equations should work
+    # for all even Nt and even Nf.
+    assert min >= 2
+    halfmin = min // 2
+    Nt = 2 * draw(st.integers(halfmin, halfmin + 5))
+    Nf = 2 * draw(st.integers(halfmin, halfmin + 5))
+    return (Nt, Nf)
+
+
+@st.composite
+def one_n_two_ms(draw, min=2):
+    Nt, Nf = draw(grid(min))
+    n = draw(st.integers(0, Nt - 1))
+    m1 = draw(st.integers(0, Nf))
+    m2 = draw(st.integers(0, Nf))
+    return (Nt, Nf, n, m1, m2)
+
+
+@st.composite
+def two_ns_one_m(draw, min=2):
+    Nt, Nf = draw(grid(min))
+    n1 = draw(st.integers(0, Nt - 1))
+    n2 = draw(st.integers(0, Nt - 1))
+    m = draw(st.integers(0, Nf))
+    return (Nt, Nf, n1, n2, m)
+
+
+# Numerical values tuned so that no counterexamples would be found
+# in the tests.
+positive = st.floats(
+    min_value=1e-200,
+    max_value=1e200,
+    exclude_min=True,
+    allow_subnormal=False,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Using max_value=0.5, exclude_max=True isn't enough.
+shape_param_a = st.floats(0, 0.5 - 1e-7)
+
+# Desired level of precision on inner products.
+atol = 1e-8
+
+
+def ortho_condition(Nf, Nt, n1, n2, m1, m2):
+    if m1 == m2:
+        if m1 in (0, Nf):
+            if n1 == n2 or abs(n1 - n2) == (Nt / 2):
+                return 0.5
+        elif n1 == n2:
+            return 1
+    return 0
+
+
+@given(one_n_two_ms(min=100), positive, shape_param_a)
+def test_ortho_twom(args, dT, a):
+    Nt, Nf, n, m1, m2 = args
+    note(f"{Nt=}, {Nf=}")
+    note(f"{n=}, {m1=}, {m2=}")
+
+    freqs = np.fft.fftfreq(Nt * Nf, dT / Nf)
+    w1 = gnmf(NUMPY_BACKEND, n, m1, freqs, dT, Nf, a, d=1)
+    w2 = gnmf(NUMPY_BACKEND, n, m2, freqs, dT, Nf, a, d=1)
+
+    norm_squared = np.sum(w1.conj() * w1).real
+
+    note(f"{norm_squared = }")
+    note(f"{w1.shape=}")
+    note(f"{w2.shape=}")
+
+    inner = np.sum(w1.conj() * w2)
+    note(f"{inner = }")
+    note(f"{abs(inner) = }")
+    assert np.isclose(inner, ortho_condition(Nf, Nt, n, n, m1, m2), atol=atol)
+
+
+@given(two_ns_one_m(min=10), positive, shape_param_a)
+def test_ortho_twon(args, dT, a):
+    Nt, Nf, n1, n2, m = args
+    note(f"{Nt=}, {Nf=}")
+    note(f"{n1=}, {n2=}, {m=}")
+
+    freqs = np.fft.fftfreq(Nt * Nf, dT / Nf)
+    w1 = gnmf(NUMPY_BACKEND, n1, m, freqs, dT, Nf, a, d=1)
+    w2 = gnmf(NUMPY_BACKEND, n2, m, freqs, dT, Nf, a, d=1)
+
+    norm_squared = np.sum(w1.conj() * w1).real
+
+    note(f"{norm_squared = }")
+    note(f"{w1.shape=}")
+    note(f"{w2.shape=}")
+
+    inner = np.sum(w1.conj() * w2)
+    note(f"{inner = }")
+    note(f"{abs(inner) = }")
+    assert np.isclose(inner, ortho_condition(Nf, Nt, n1, n2, m, m), atol=atol)
+
+
+def test_normalization():
+    # The point of this was originally to dig deeper into normalization issues.
+    # After updating to latest code those issues are gone.
+    # This test just tells us that the normalization works fine.
+
+    def norm(Nf, Nt, n, m):
+        dt = 1
+        freqs = np.fft.fftfreq(Nt * Nf, dt)
+        xp = np
+        nt = int(xp.asarray(freqs).shape[-1]) // int(Nf)
+        assert nt == Nt
+        g = gnmf(NUMPY_BACKEND, n, m, freqs, Nf * dt, Nf, 0.49, 1)
+        return np.sum(g.conj() * g).real
+
+    def comp(Nf, Nt, n, m, expected=1):
+        n1 = norm(Nf, Nt, n, m)
+        close = np.isclose(n1, expected)
+        return f"{n1:.10f} {close}"
+
+    # Reproducing I saw in the property test
+    assert comp(10, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(14, 14, 0, 1) == snapshot("1.0000000000 True")
+
+    # It seems unaffected by n
+    assert comp(10, 10, 1, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 10, 1, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 12, 1, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 12, 1, 1) == snapshot("1.0000000000 True")
+    assert comp(14, 14, 1, 1) == snapshot("1.0000000000 True")
+
+    # fixed Nf=10, changing Nt
+    assert comp(10, 8, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 14, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 16, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 18, 0, 1) == snapshot("1.0000000000 True")
+
+    # fixed Nt=10, changing Nf
+    assert comp(8, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(14, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(16, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(18, 10, 0, 1) == snapshot("1.0000000000 True")
+
+    # fixed Nf=12, changing Nt
+    assert comp(12, 8, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 10, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 14, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 16, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 18, 0, 1) == snapshot("1.0000000000 True")
+
+    # fixed Nt=12, changing Nf
+    assert comp(8, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(10, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(12, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(14, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(16, 12, 0, 1) == snapshot("1.0000000000 True")
+    assert comp(18, 12, 0, 1) == snapshot("1.0000000000 True")
+
+    # norm at edge channels is 0.5
+    assert comp(10, 10, 0, 0, 0.5) == snapshot("0.5000000000 True")
+    assert comp(10, 10, 0, 10, 0.5) == snapshot("0.5000000000 True")

--- a/uv.lock
+++ b/uv.lock
@@ -1109,6 +1109,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.155.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/04/64032a1dccd2233615c8a3f701bbb563558575ed017496a24b6d81762c91/hypothesis-6.155.2.tar.gz", hash = "sha256:ae36880287c9c5defe9f199d3d2b67d9947a4da2a46e6c57373cbdf2345b20e1", size = 477765, upload-time = "2026-06-05T16:32:23.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6e/e735f27ac1a530a4cd0a31cd970ec495a3a11830fdc5d281cc292593b330/hypothesis-6.155.2-py3-none-any.whl", hash = "sha256:c85ce6dcd630a90ce501f1d1dd1bc84b97f5649ca8a27e134c8cbf5aa480b1a5", size = 544213, upload-time = "2026-06-05T16:32:21.15Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1133,6 +1146,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pytest" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/2e/00c99468c7788bdb4f7d861bcfbfb091a5fe1bc475f9dd031f667c422a73/inline_snapshot-0.34.1.tar.gz", hash = "sha256:f8af37876c42069b7c0ed73f64357ace482955c3225ebcd27f243197ecfbcb65", size = 2638769, upload-time = "2026-06-05T16:58:47.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/83/21747d0ee2276e973a2889e960f2ec904fbbe83fac6fecd8a57995bb81df/inline_snapshot-0.34.1-py3-none-any.whl", hash = "sha256:4c043215866dfdbe6a3ead92d9d0a9294720c7deebddc346dc781654cb19daa9", size = 90039, upload-time = "2026-06-05T16:58:46.038Z" },
 ]
 
 [[package]]
@@ -3178,6 +3208,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3478,6 +3521,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3755,6 +3807,8 @@ jax = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
+    { name = "inline-snapshot" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-markdown-docs" },
@@ -3790,6 +3844,8 @@ provides-extras = ["jax", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.155.2" },
+    { name = "inline-snapshot", specifier = ">=0.34.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-markdown-docs", specifier = ">=0.6" },


### PR DESCRIPTION
This PR adds two property-based tests of orthogonality of `gnmf()`. Property-based tests are randomly generated in a large parameter space; the fact that they pass gives me confidence that the wave packets are orthonormal as claimed in the paper, without checking the proof.

The test is that, to precision 1e-8, using shape parameter A in the interval [0, 0.5 - 1e-7], for all even (Nt, Nf) in {2, 4, 6, 8, 10}, gnmf obeys the orthonormality condition given in the paper (`ortho_condition()`). One test is for same n, different m, the other is the opposite. I have run these tests on higher numbers and the precision seems to just get better.

You can delete `test_normalization()` if you prefer. It's mostly a regression test because I used to see issues in it (beginning of June) that disappeared after I pulled the latest commit from main around June 10.

Note that I disabled the jax backend in the test (need to uncomment if you want to run that). It's because it's very slow, due to an unknown overhead.